### PR TITLE
AS-3060: data directory path change from ibm to hcl

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ ounce:project<br>
     installDir
       The location of the Ounce client installation directory. Required if
       ounceauto is not on the path.
+      NOTE: As of version 10.0.7, AppScan Source has an updated installation path.
+      AppScan Source Ounce/Maven plugin has been updated to handle both the old and new installation paths by default.
       Expression: ${ounce.installDir}
 
     javaCompilerOptions
@@ -297,7 +299,10 @@ ounce:project-only<br>
     installDir
       The location of the Ounce client installation directory. Required if
       ounceauto is not on the path.
+      NOTE: As of version 10.0.7, AppScan Source has an updated installation path.
+      AppScan Source Ounce/Maven plugin has been updated to handle both the old and new installation paths by default.
       Expression: ${ounce.installDir}
+
 
     javaCompilerOptions
       Options to pass to the javac compiler.
@@ -510,6 +515,8 @@ ounce:report<br>
 	installDir
       The location of the Ounce client installation directory if the Ounce
       client is not on the path.
+      NOTE: As of version 10.0.7, AppScan Source has an updated installation path.
+      AppScan Source Ounce/Maven plugin has been updated to handle both the old and new installation paths by default.
       Command line variable: -Dounce.installDir
       Example: Dounce.installDir='C:\Program Files (x86)\IBM\AppScanSource'
       Expression: ${ounce.installDir}
@@ -669,6 +676,8 @@ ounce:scan<br>
     installDir
       The location of the Ounce client installation directory if the Ounce
       client is not on the path.
+      NOTE: As of version 10.0.7, AppScan Source has an updated installation path.
+      AppScan Source Ounce/Maven plugin has been updated to handle both the old and new installation paths by default.
       Command line variable: -Dounce.installDir
       Example: Dounce.installDir='C:\Program Files (x86)\IBM\AppScanSource'
       Expression: ${ounce.installDir}

--- a/src/main/java/org/codehaus/mojo/ounce/core/OunceCoreXmlSerializer.java
+++ b/src/main/java/org/codehaus/mojo/ounce/core/OunceCoreXmlSerializer.java
@@ -1020,7 +1020,9 @@ public class OunceCoreXmlSerializer implements OunceCore
     		}
     		if(opSys.equals("Linux"))
     		{
-    			File cli = new File("/var/opt/ibm/appscansource/logs/maven_ounceauto.sh");
+    			File cli = new File("/var/opt/hcl/appscansource").exists()
+    					? new File("/var/opt/hcl/appscansource/logs/maven_ounceauto.sh")
+    					: new File("/var/opt/ibm/appscansource/logs/maven_ounceauto.sh");
     			cli.setExecutable(true);
     			FileWriter fw = new FileWriter(cli);
     			fw.append(command);


### PR DESCRIPTION
@mattmurp 

**Issue:**
AppScan Source is upgraded to use IBM Semeru JDK/JRE and the Product path has also been changed from IBM to HCL so the new installation path would be /var/opt/hcl/appscansource/ but the data-dir path is hardcoded to use IBM path hence AppScan maven cmd is failing to Linux in Linux OS.

**Fix:**
Code changes are first, it checks for the HCL path if it doesn't exist then it will look for the IBM path.

For more details please refer: https://jira02.hclpnp.com/browse/AS-3060

**Tested Scenarios by Testing team:**

1. Tested with a given jar which is built locally with 10.0.7 AppScan Source installed (which has product and IBM JRE changes) working as expected
2. Tested with AppScan Source 10.0.6 or earlier version also in which the install path is IBM to make sure latest changes works fine with the old version of source.