### PR TITLE
AS-3103 | Ounce maven plugin 1.6.2 is not including the .ppf file from subdirectories in .paf file.

### DIFF
--- a/src/main/java/org/codehaus/mojo/ounce/AbstractOunceMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/AbstractOunceMojo.java
@@ -58,6 +58,15 @@ public abstract class AbstractOunceMojo
 	@Parameter (property="project", readonly=true)
     protected MavenProject project;
 
+	/**
+     * Specifies the directory where to create the ppf file
+     * 
+     * 
+     */
+    @Parameter (property="ounce.projectDir", defaultValue="${basedir}")
+    protected String projectDir;
+    
+	
     /**
      * The Maven Session Object
      * 

--- a/src/main/java/org/codehaus/mojo/ounce/AbstractOunceMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/AbstractOunceMojo.java
@@ -89,7 +89,7 @@ public abstract class AbstractOunceMojo
      * 
      * 
      */
-	@Parameter (property="ounce.projectFile",  defaultValue="${project.artifactId}", readonly=true)
+	@Parameter (defaultValue="${project.artifactId}", readonly=true)
     protected String name;
 
     /**

--- a/src/main/java/org/codehaus/mojo/ounce/ApplicationMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/ApplicationMojo.java
@@ -273,11 +273,13 @@ public class ApplicationMojo
          while (iter.hasNext()) {
             MavenProject prj = (MavenProject) iter.next();
             if (!skipPoms || !prj.getPackaging().equalsIgnoreCase("pom")) {
+            	//To check if project directory param is passed. if project directory is not passed 
+               // if param is paased then file project directory path will be added in PAF else default path 
             	if(getProjectRoot().equalsIgnoreCase(projectDir)) {    
             		beanProjects.add(new OunceProjectBean(prj.getBasedir().getPath(), prj.getArtifactId()));
                 }else {
             		beanProjects.add(new OunceProjectBean(projectDir, prj.getArtifactId()));
-             }	
+               }	
 		     }
             else
                 getLog().debug( "Skipping Pom: " + prj.getArtifactId() );

--- a/src/main/java/org/codehaus/mojo/ounce/ApplicationMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/ApplicationMojo.java
@@ -276,14 +276,14 @@ public class ApplicationMojo
     private List<OunceProjectBean> convertToBeans(List<OunceProjectBean> theProjects)
     {
         List<OunceProjectBean> beanProjects = new ArrayList<OunceProjectBean>(theProjects.size());
-
         Iterator iter = theProjects.iterator();
         while (iter.hasNext()) {
             MavenProject prj = (MavenProject) iter.next();
 
             if (!skipPoms || !prj.getPackaging().equalsIgnoreCase("pom")) {
-				beanProjects.add( new OunceProjectBean(projectDir, name));
-            }
+            	
+           	  	 beanProjects.add(new OunceProjectBean(projectDir, prj.getArtifactId()));
+		     }
             else
                 getLog().debug( "Skipping Pom: " + prj.getArtifactId() );
         }

--- a/src/main/java/org/codehaus/mojo/ounce/ApplicationMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/ApplicationMojo.java
@@ -127,13 +127,6 @@ public class ApplicationMojo
 	@Parameter
     protected List externalApplications;
     
-    /**
-     * Specifies the directory where to create the ppf file
-     * 
-     * 
-     */
-	@Parameter (property="ounce.projectDir", defaultValue="${basedir}")
-    private String projectDir;
     
     /**
      * Specifies the directory where to create the paf file
@@ -275,13 +268,16 @@ public class ApplicationMojo
      */
     private List<OunceProjectBean> convertToBeans(List<OunceProjectBean> theProjects)
     {
-        List<OunceProjectBean> beanProjects = new ArrayList<OunceProjectBean>(theProjects.size());
+    	List<OunceProjectBean> beanProjects = new ArrayList<OunceProjectBean>(theProjects.size());
         Iterator iter = theProjects.iterator();
-        while (iter.hasNext()) {
+         while (iter.hasNext()) {
             MavenProject prj = (MavenProject) iter.next();
-
             if (!skipPoms || !prj.getPackaging().equalsIgnoreCase("pom")) {
-            	beanProjects.add(new OunceProjectBean(prj.getBasedir().getPath(), prj.getArtifactId()));
+            	if(getProjectRoot().equalsIgnoreCase(projectDir)) {    
+            		beanProjects.add(new OunceProjectBean(prj.getBasedir().getPath(), prj.getArtifactId()));
+                }else {
+            		beanProjects.add(new OunceProjectBean(projectDir, prj.getArtifactId()));
+             }	
 		     }
             else
                 getLog().debug( "Skipping Pom: " + prj.getArtifactId() );

--- a/src/main/java/org/codehaus/mojo/ounce/ApplicationMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/ApplicationMojo.java
@@ -281,8 +281,7 @@ public class ApplicationMojo
             MavenProject prj = (MavenProject) iter.next();
 
             if (!skipPoms || !prj.getPackaging().equalsIgnoreCase("pom")) {
-            	
-           	  	 beanProjects.add(new OunceProjectBean(projectDir, prj.getArtifactId()));
+            	beanProjects.add(new OunceProjectBean(prj.getBasedir().getPath(), prj.getArtifactId()));
 		     }
             else
                 getLog().debug( "Skipping Pom: " + prj.getArtifactId() );

--- a/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
@@ -194,13 +194,6 @@ public class ProjectOnlyMojo extends AbstractOunceMojo
     @Parameter (property="ounce.precompileScan", defaultValue="false")
     private boolean precompileScan;
     
-    /**
-     * Specifies the directory where to create the ppf file
-     * 
-     * 
-     */
-    @Parameter (property="ounce.projectDir", defaultValue="${basedir}")
-    private String projectDir;
     
     /**
      * Specifies the directory where to create the paf file
@@ -266,7 +259,7 @@ public class ProjectOnlyMojo extends AbstractOunceMojo
         if (includeTestSources)
             sourceRoots.addAll(project.getTestCompileSourceRoots());
         
-        return Utils.convertToRelativePaths(sourceRoots, projectDir);
+         return Utils.convertToRelativePaths(sourceRoots, projectDir);
     }
     
     protected Map<String, String> getOptions() {


### PR DESCRIPTION
Hi @mattmurp ,

raising pull request for below APAR fix. more details are available in AS-3103

 [APAR-KB0098384] Ounce maven plugin 1.6.2 is not including the .ppf file from subdirectories in .paf file.