### PR TITLE
AS-3442

### DIFF
--- a/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
@@ -373,9 +373,9 @@ public class ProjectOnlyMojo extends AbstractOunceMojo
             return "";
 
         // if maven-war-plugin and its warName property exists then update name of war file by the value given in warName property.  
-        String warName = Utils.getValueOfProperty(project, "org.apache.maven.plugins", "maven-war-plugin", "warName");
-        if(warName !=null)
-        	webappDirectory = project.getBuild().getDirectory().concat(File.separator).concat(warName).concat(".war");
+        String warNameFromPlugin = Utils.getValueOfProperty(project, "org.apache.maven.plugins", "maven-war-plugin", "warName");
+        if(warNameFromPlugin !=null)
+        	webappDirectory = project.getBuild().getDirectory().concat(File.separator).concat(warNameFromPlugin).concat(".war");
 
         return Utils.makeRelative(webappDirectory, projectDir);
     }

--- a/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
@@ -367,19 +367,16 @@ public class ProjectOnlyMojo extends AbstractOunceMojo
     /**
      * Gets the path to the generated webapp directory for war projects.
      * 
-     * @return The path to the generated webapp directory or the empty string if this project is not a war project.
+     * @return The relative path to the generated war file or the empty string if this project is not a war project.
      */
     protected String getWebRoot() {
         if (!project.getPackaging().equalsIgnoreCase("war"))
             return "";
 
-        // if maven-war-plugin and its warName property exists then update name of war file in webappDirectory by value given in warName property.  
-        Xpp3Dom warConfigDom = (Xpp3Dom) project.getPlugin("org.apache.maven.plugins:maven-war-plugin").getConfiguration();
-        if (warConfigDom != null) {
-            Xpp3Dom varNameDom = warConfigDom.getChild("warName");
-            if (varNameDom != null)
-                webappDirectory = project.getBuild().getDirectory().concat(File.separator).concat(varNameDom.getValue()).concat(".war");
-        }
+        // if maven-war-plugin and its warName property exists then update name of war file by the value given in warName property.  
+        String warName = Utils.getValueOfProperty(project, "org.apache.maven.plugins", "maven-war-plugin", "warName");
+        if(warName !=null)
+        	webappDirectory = project.getBuild().getDirectory().concat(File.separator).concat(warName).concat(".war");
 
         return Utils.makeRelative(webappDirectory, projectDir);
     }

--- a/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
@@ -45,7 +45,6 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.codehaus.mojo.ounce.core.OunceCoreException;
 import org.codehaus.mojo.ounce.utils.Utils;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 /**
  * This mojo generates an Ounce project file. It does not fork the build like the "project" mojo and is instead intended

--- a/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
@@ -45,6 +45,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.codehaus.mojo.ounce.core.OunceCoreException;
 import org.codehaus.mojo.ounce.utils.Utils;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 /**
  * This mojo generates an Ounce project file. It does not fork the build like the "project" mojo and is instead intended
@@ -368,12 +369,20 @@ public class ProjectOnlyMojo extends AbstractOunceMojo
      * 
      * @return The path to the generated webapp directory or the empty string if this project is not a war project.
      */
-    protected String getWebRoot() {
-    	if(!project.getPackaging().equalsIgnoreCase("war"))
-    		return "";
-    	
-    	return Utils.makeRelative(webappDirectory, projectDir);
-    }
+	protected String getWebRoot() {
+        if (!project.getPackaging().equalsIgnoreCase("war"))
+            return "";
+
+        // if maven-war-plugin and its warName property exists then update name of war file in webappDirectory by value given in warName property.  
+        Xpp3Dom warConfigDom = (Xpp3Dom) project.getPlugin("org.apache.maven.plugins:maven-war-plugin").getConfiguration();
+        if (warConfigDom != null) {
+            Xpp3Dom varNameDom = warConfigDom.getChild("warName");
+            if (varNameDom != null)
+                webappDirectory = project.getBuild().getDirectory().concat(File.separator).concat(varNameDom.getValue()).concat(".war");
+        }
+
+        return Utils.makeRelative(webappDirectory, projectDir);
+	}
 	
 	private void configureVariables() throws OunceCoreException, ComponentLookupException {
         if ( pathVariableMap == null )

--- a/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
@@ -375,7 +375,7 @@ public class ProjectOnlyMojo extends AbstractOunceMojo
         // if maven-war-plugin and its warName property exists then update name of war file by the value given in warName property.  
         String warNameFromPlugin = Utils.getValueOfProperty(project, "org.apache.maven.plugins", "maven-war-plugin", "warName");
         if(warNameFromPlugin !=null)
-        	webappDirectory = project.getBuild().getDirectory().concat(File.separator).concat(warNameFromPlugin).concat(".war");
+            webappDirectory = project.getBuild().getDirectory().concat(File.separator).concat(warNameFromPlugin).concat(".war");
 
         return Utils.makeRelative(webappDirectory, projectDir);
     }

--- a/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
+++ b/src/main/java/org/codehaus/mojo/ounce/ProjectOnlyMojo.java
@@ -369,7 +369,7 @@ public class ProjectOnlyMojo extends AbstractOunceMojo
      * 
      * @return The path to the generated webapp directory or the empty string if this project is not a war project.
      */
-	protected String getWebRoot() {
+    protected String getWebRoot() {
         if (!project.getPackaging().equalsIgnoreCase("war"))
             return "";
 
@@ -382,7 +382,7 @@ public class ProjectOnlyMojo extends AbstractOunceMojo
         }
 
         return Utils.makeRelative(webappDirectory, projectDir);
-	}
+    }
 	
 	private void configureVariables() throws OunceCoreException, ComponentLookupException {
         if ( pathVariableMap == null )

--- a/src/main/java/org/codehaus/mojo/ounce/utils/Utils.java
+++ b/src/main/java/org/codehaus/mojo/ounce/utils/Utils.java
@@ -38,7 +38,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 public class Utils
 {
@@ -213,5 +215,23 @@ public class Utils
 			}
 		}
 		return ret;
+	}
+	/**
+	 * Get value of a plugin's property
+	 * @param project maven project
+	 * @param groupId groupId of the plugin
+	 * @param artifactId artifactId of the plugin
+	 * @param property name of the property
+	 * @return value of the property
+	 */
+	public static String getValueOfProperty(MavenProject project, String groupId, String artifactId, String property) {
+		String propVal = null;
+		Xpp3Dom configDom = (Xpp3Dom) project.getPlugin(groupId + ":" + artifactId).getConfiguration();
+		if (configDom != null) {
+			Xpp3Dom propDom = configDom.getChild(property);
+			if (propDom != null)
+				propVal = propDom.getValue();
+		}
+		return propVal;
 	}
 }


### PR DESCRIPTION
Hi,

Ounce Maven plugin were ignoring the "warName" property.  Did code change to take war name from maven-war-plugin if it presents in pom.xml. code change is tested with positive and negative scenario. When we remove only warName property or full maven-war-plugin, it generate PPF file with "artifactId-version".war . If maven-war-plugin present and it has warName property, it read war name from "warName" property and create PPF file. Please review.

Thanks,
Rakesh